### PR TITLE
Simplify repository config

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint ./src",
     "test": "npm run lint"
   },
-  "repository": "https://github.com/liuderchi/ide-css.git",
+  "repository": "liuderchi/ide-css",
   "keywords": [
     "atom-ide",
     "css",


### PR DESCRIPTION
The `respository` config can be simplified by since it uses GitHub as default. This is common in a lot of big packages. 

Example: https://github.com/avajs/ava/blob/0e82b044a1a5af35286df344275ef779431aac3a/package.json#L6 