### PR TITLE
Add activationHooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
   "engines": {
     "atom": ">=1.21.0"
   },
+  "activationHooks": [
+    "source.css:root-scope-used",
+    "source.css.less:root-scope-used",
+    "source.css.scss:root-scope-used"
+  ],
   "enhancedScopes": [
     "source.css",
     "source.css.less",


### PR DESCRIPTION
Hi, this PR suggests ide-css uses `activationHooks` for better loading time.

## Purpose

Introduce `actiavationHooks`:
- Only activates this packages when an user actually uses this package
     * It's activated when an user opens files with CSS/LESS/SCSS scope (or s/he switches the file scope from the other one into one of them)
- Better packages loading time when an user doesn't open CSS/LESS/SCSS files throughout one Atom process

## Notes

The difference from `enhancedScopes`:
- `enhancedScopes` only controls the scopes within which this package can be used AFAIU

## Fallbacks

I've never noticed the downside of this change

## Misc

You can see [ide-typescript](https://github.com/atom/ide-typescript/) as the other Atom-IDE package, which uses this logic:
https://github.com/atom/ide-typescript/blob/master/package.json#L68-L73